### PR TITLE
fix: 32652204 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15393,7 +15393,6 @@
         "@xipkg/modal": "^1.5.0",
         "@xipkg/utils": "1.0.1",
         "next": "^13.5.6",
-        "pkg.module.add-community": "^0.0.0",
         "react": "^18.2.0",
         "zod": "3.22.4"
       },
@@ -15564,6 +15563,7 @@
         "pkg.community.settings": "*",
         "pkg.logo": "*",
         "pkg.models": "*",
+        "pkg.module.add-community": "*",
         "pkg.router.url": "*",
         "pkg.stores": "*",
         "pkg.user.settings": "*",

--- a/packages/pkg.module.add-community/AddCommunityModal.tsx
+++ b/packages/pkg.module.add-community/AddCommunityModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { Button } from '@xipkg/button';
 import { Close } from '@xipkg/icons';
 import * as M from '@xipkg/modal';

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -254,7 +254,7 @@ export const CommunityMenu = () => {
                       <span>Пройти обучение</span>
                       <Objects size="s" className="ml-auto h-4 w-4 group-hover:fill-gray-100" />
                     </DropdownMenuItem>
-                    <DropdownMenuSeparator />
+                    <DropdownMenuSeparator className="hidden md:flex" />
                     <DropdownMenuItem className="group sm:w-[302px]">
                       <span>Пригласить людей</span>
                       <PeopleInvite

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { AddCommunityModal } from 'pkg.module.add-community';
+import { AddCommunityModal } from '../../pkg.module.add-community';
 
 import {
   CategoryAdd,
@@ -250,7 +250,7 @@ export const CommunityMenu = () => {
                 />
                 {currentCommunity.isOwner && (
                   <>
-                    <DropdownMenuItem onClick={driverAction} className="group sm:w-[302px]">
+                    <DropdownMenuItem onClick={driverAction} className="group sm:w-[302px] hidden md:flex">
                       <span>Пройти обучение</span>
                       <Objects size="s" className="ml-auto h-4 w-4 group-hover:fill-gray-100" />
                     </DropdownMenuItem>

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import { AddCommunityModal } from '../../pkg.module.add-community';
+import { AddCommunityModal } from 'pkg.module.add-community';
 
 import {
   CategoryAdd,

--- a/packages/pkg.navigation/package.json
+++ b/packages/pkg.navigation/package.json
@@ -29,7 +29,8 @@
     "pkg.models": "*",
     "pkg.logo": "*",
     "pkg.stores": "*",
-    "pkg.utils": "*"
+    "pkg.utils": "*",
+    "pkg.module.add-community": "*"
   },
   "devDependencies": {
     "eslint-config-custom": "*",


### PR DESCRIPTION
Добавлено условие для скрытия пункта Меню сообщества "Пройти обучение" на мобильных устройствах (md).
 * пришлось поменять путь импорта AddCommunityModal, тк появлялась ошибка 
<img width="691" alt="Снимок экрана 2024-04-21 в 13 40 30" src="https://github.com/xi-effect/xi.app/assets/38958605/4e2da816-05b1-49bd-8fae-c275eb3531fa">
... и добавить импорт React