### PR TITLE
33109807: save params on redirect

### DIFF
--- a/apps/xi.front/app/providers.tsx
+++ b/apps/xi.front/app/providers.tsx
@@ -159,11 +159,9 @@ const AuthProvider = ({ children }: AuthProviderT) => {
 
   // Сохраняем уникальные параметры при редиректе
   const getUrlWithParams = (url: string) => {
-    const params = searchParams.toString();
-    const uniqueParams = new Set(params.split('&'));
-    const uniqueParamsString = Array.from(uniqueParams).join();
+    const params = new URLSearchParams(Object.fromEntries(searchParams)).toString();
 
-    return uniqueParamsString ? `${url}?${uniqueParamsString}` : url;
+    return params ? `${url}?${params}` : url;
   };
 
   // Если пользователь не залогинен,

--- a/apps/xi.front/app/providers.tsx
+++ b/apps/xi.front/app/providers.tsx
@@ -2,7 +2,7 @@
 
 import { ThemeProvider } from 'next-themes';
 import { redirect, useParams, usePathname, useSearchParams } from 'next/navigation';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, Suspense } from 'react';
 import { toast, Toaster } from 'sonner';
 import { useMainSt } from 'pkg.stores';
 import Load from './load';
@@ -207,8 +207,10 @@ type ProvidersT = {
 export const Providers = ({ children }: ProvidersT) => (
   <ThemeProvider defaultTheme="light" themes={['light', 'dark']} attribute="data-theme">
     <Toaster visibleToasts={1} />
-    <AuthProvider>
-      <SocketProvider>{children}</SocketProvider>
-    </AuthProvider>
+    <Suspense fallback={<Load />}>
+      <AuthProvider>
+        <SocketProvider>{children}</SocketProvider>
+      </AuthProvider>
+    </Suspense>
   </ThemeProvider>
 );


### PR DESCRIPTION
Настроено сохранение параметров для providers.tsx

Но есть такой момент, что если на странице сообщества, например /communities/27, добавить параметр, а потом перейти в меню юзера и обратно, то параметры будут накапливаться в геометрической прогрессии. 
![image](https://github.com/xi-effect/xi.app/assets/106012155/ac59921f-9ab2-4dab-99ca-4114189bb8d1)
![image](https://github.com/xi-effect/xi.app/assets/106012155/de86b9b0-e11d-4b8b-96ec-52f5de984182)

Могу в рамках PR поискать ещё такое и поправить