### PR TITLE
34915851

### DIFF
--- a/apps/xi.front/app/communities/[community-id]/home/page.tsx
+++ b/apps/xi.front/app/communities/[community-id]/home/page.tsx
@@ -34,8 +34,8 @@ const Header = () => {
 
   return (
     <header className=" max-xs:pb-4 pb-8 w-full max-w-[1570px]">
-      <div className="font-semibold text-[32px] max-xs:text-2xl leading-10 xl:text-[40px] xl:leading-[48px] flex gap-3 sm:gap-4 flex-wrap text-gray-100">
-        <h2 className="mr-3 sm:mr-4">Добро пожаловать в сообщество</h2>
+      <div className="font-semibold text-[32px] max-xs:text-2xl leading-10 xl:text-[40px] xl:leading-[48px] flex gap-3 flex-wrap text-gray-100">
+        <h2 className="mr-3">Добро пожаловать в сообщество</h2>
         <div className="flex items-center">
           {!id ? (
             <div className="bg-gray-10 size-[48px] animate-pulse rounded-[24px]" />

--- a/apps/xi.front/app/communities/[community-id]/home/page.tsx
+++ b/apps/xi.front/app/communities/[community-id]/home/page.tsx
@@ -45,7 +45,7 @@ const Header = () => {
           {!communityName ? (
             <div className="ml-2 xl:ml-4 animate-pulse bg-gray-10 h-[32px] w-[156px] rounded-[8px]" />
           ) : (
-            <p className="ml-2 xl:ml-4">{communityName}</p>
+            <p className="ml-2 xl:ml-4 break-all">{communityName}</p>
           )}
         </div>
       </div>

--- a/apps/xi.front/app/communities/[community-id]/home/page.tsx
+++ b/apps/xi.front/app/communities/[community-id]/home/page.tsx
@@ -34,9 +34,9 @@ const Header = () => {
 
   return (
     <header className=" max-xs:pb-4 pb-8 w-full max-w-[1570px]">
-      <div className="font-semibold text-[32px] max-xs:text-2xl leading-10 xl:text-[40px] xl:leading-[48px] xl:flex text-gray-100">
-        <h2>Добро пожаловать в сообщество</h2>
-        <div className="flex items-center max-xl:mt-3 max-xs:mt-0 xl:ml-6">
+      <div className="font-semibold text-[32px] max-xs:text-2xl leading-10 xl:text-[40px] xl:leading-[48px] flex gap-3 sm:gap-4 flex-wrap text-gray-100">
+        <h2 className="mr-3 sm:mr-4">Добро пожаловать в сообщество</h2>
+        <div className="flex items-center">
           {!id ? (
             <div className="bg-gray-10 size-[48px] animate-pulse rounded-[24px]" />
           ) : (
@@ -45,7 +45,9 @@ const Header = () => {
           {!communityName ? (
             <div className="ml-2 xl:ml-4 animate-pulse bg-gray-10 h-[32px] w-[156px] rounded-[8px]" />
           ) : (
-            <p className="ml-2 xl:ml-4 break-all">{communityName}</p>
+            <p className="ml-2 xl:ml-4 supports-[overflow-wrap:anywhere]:[overflow-wrap:anywhere] supports-[not(overflow-wrap:anywhere)]:[word-break:normal]">
+              {communityName}
+            </p>
           )}
         </div>
       </div>

--- a/apps/xi.front/app/welcome/community-create/page.tsx
+++ b/apps/xi.front/app/welcome/community-create/page.tsx
@@ -115,7 +115,7 @@ export default function WelcomeCommunityCreate() {
 
   const onSubmit = ({ community }: z.infer<typeof FormSchema>) => {
     setIsLoading(true);
-    console.log("onSubmit", socket);
+    console.log('onSubmit', socket);
     socket.emit(
       'create-community',
       {

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -168,12 +168,12 @@ const CommunityLink = ({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="overflow-hidden bg-transparent">
-            <div className="ml-2 self-center text-[16px] font-semibold truncate" ref={communityTitleRef}>
+            <div className="ml-2 self-center text-[16px] font-semibold truncate text-gray-100" ref={communityTitleRef}>
               {community.name}
             </div>
           </TooltipTrigger>
           <TooltipContent className={`max-w-[300px] ${isTooltipActive ? 'flex' : 'hidden'}`}>
-            <p>{community.name}</p>
+            <p className="text-gray-100">{community.name}</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -9,6 +9,7 @@ import { CommunitySettings } from 'pkg.community.settings';
 import { AddCommunityModal } from 'pkg.modal.add-community';
 import { CommunityChannelCreate } from 'pkg.community.channel-create';
 import { InviteCommunityModal } from 'pkg.modal.invite-community';
+import { ScrollArea } from '@xipkg/scrollarea';
 
 import {
   CategoryAdd,
@@ -304,11 +305,13 @@ export const CommunityMenu = () => {
               </DropdownMenuItem>
             </div>
             {otherCommunities && (
-              <div className="mt-2">
-                {otherCommunities.map((community, index) => (
-                  <CommunityLink key={index} community={community} handleClose={handleClose} />
-                ))}
-              </div>
+              <ScrollArea className="h-[300px]">
+                <div className="mt-2">
+                  {otherCommunities.map((community, index) => (
+                    <CommunityLink key={index} community={community} handleClose={handleClose} />
+                  ))}
+                </div>
+              </ScrollArea>
             )}
             <DropdownMenuSeparator />
             <AddCommunityModal

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -87,7 +87,7 @@ const DropdownHeader = ({
     {!name ? (
       <div className="bg-gray-10 ml-2 h-4 w-[156px] animate-pulse self-center rounded-[2px] text-[16px] font-semibold" />
     ) : (
-      <div className="ml-2 self-center text-[16px] font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{name}</div>
+      <div className="ml-2 self-center text-[16px] font-semibold truncate">{name}</div>
     )}
     <div className="ml-auto flex h-4 w-4 flex-col items-center justify-center">
       <ChevronSmallTop
@@ -147,10 +147,10 @@ const CommunityLink = ({
   return (
     <div
       onClick={handleClick}
-      className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer md:w-[300px]"
+      className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer w-full"
     >
       <AvatarPreview communityId={community.id} />
-      <div className="ml-2 self-center text-[16px] font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{community.name}</div>
+      <div className="ml-2 self-center text-[16px] font-semibold truncate">{community.name}</div>
     </div>
   );
 };
@@ -305,7 +305,7 @@ export const CommunityMenu = () => {
               </DropdownMenuItem>
             </div>
             {otherCommunities && (
-              <ScrollArea className="h-[300px]">
+              <ScrollArea className="h-[300px] [&>div>div[style]]:!block">
                 <div className="mt-2">
                   {otherCommunities.map((community, index) => (
                     <CommunityLink key={index} community={community} handleClose={handleClose} />

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -10,6 +10,12 @@ import { AddCommunityModal } from 'pkg.modal.add-community';
 import { CommunityChannelCreate } from 'pkg.community.channel-create';
 import { InviteCommunityModal } from 'pkg.modal.invite-community';
 import { ScrollArea } from '@xipkg/scrollarea';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@xipkg/tooltip';
 
 import {
   CategoryAdd,
@@ -20,7 +26,7 @@ import {
   Settings,
   Plus,
 } from '@xipkg/icons';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -109,6 +115,8 @@ const CommunityLink = ({
   const currentCommunityId = useMainSt((state) => state.communityMeta.id);
   const updateCommunityMeta = useMainSt((state) => state.updateCommunityMeta);
   const router = useRouter();
+  const communityTitleRef = useRef<HTMLDivElement>(null);
+  const [isTooltipActive, setIsTooltipActive] = React.useState(false);
 
   const handleClick = () => {
     socket.emit(
@@ -144,13 +152,31 @@ const CommunityLink = ({
     );
   };
 
+  useEffect(() => {
+    const element = communityTitleRef.current;
+    if (element && (element.clientWidth < element.scrollWidth)) {
+      setIsTooltipActive(true);
+    }
+  }, []);
+
   return (
     <div
       onClick={handleClick}
       className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer w-full"
     >
       <AvatarPreview communityId={community.id} />
-      <div className="ml-2 self-center text-[16px] font-semibold truncate">{community.name}</div>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger className="overflow-hidden bg-transparent">
+            <div className="ml-2 self-center text-[16px] font-semibold truncate" ref={communityTitleRef}>
+              {community.name}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent className={`max-w-[300px] ${isTooltipActive ? 'flex' : 'hidden'}`}>
+            <p>{community.name}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 };

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -160,24 +160,24 @@ const CommunityLink = ({
   }, []);
 
   return (
-    <div
-      onClick={handleClick}
-      className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer w-full"
-    >
-      <AvatarPreview communityId={community.id} />
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger className="overflow-hidden bg-transparent">
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="overflow-hidden bg-transparent" asChild>
+          <div
+            onClick={handleClick}
+            className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer w-full"
+          >
+            <AvatarPreview communityId={community.id} />
             <div className="ml-2 self-center text-[16px] font-semibold truncate text-gray-100" ref={communityTitleRef}>
               {community.name}
             </div>
-          </TooltipTrigger>
-          <TooltipContent className={`max-w-[300px] ${isTooltipActive ? 'flex' : 'hidden'}`}>
-            <p className="text-gray-100">{community.name}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent className={`max-w-[300px] ${isTooltipActive ? 'flex' : 'hidden'}`}>
+          <p className="text-gray-100">{community.name}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 

--- a/packages/pkg.navigation/components/CommunityMenu.tsx
+++ b/packages/pkg.navigation/components/CommunityMenu.tsx
@@ -74,7 +74,7 @@ const DropdownHeader = ({
     onClick={() => {
       if (name) setIsOpen((prev: boolean) => !prev);
     }}
-    className={`flex h-12 flex-wrap px-2.5 py-2 md:w-[302px] ${!name ? 'cursor-not-allowed' : 'cursor-pointer'} ${
+    className={`flex h-12 px-2.5 py-2 md:w-[302px] ${!name ? 'cursor-not-allowed' : 'cursor-pointer'} ${
       inDropdown ? '' : 'mt-0 sm:mt-8'
     } hover:bg-gray-5 items-center rounded-xl transition-colors ease-in`}
   >
@@ -86,7 +86,7 @@ const DropdownHeader = ({
     {!name ? (
       <div className="bg-gray-10 ml-2 h-4 w-[156px] animate-pulse self-center rounded-[2px] text-[16px] font-semibold" />
     ) : (
-      <div className="ml-2 self-center text-[16px] font-semibold">{name}</div>
+      <div className="ml-2 self-center text-[16px] font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{name}</div>
     )}
     <div className="ml-auto flex h-4 w-4 flex-col items-center justify-center">
       <ChevronSmallTop
@@ -146,10 +146,10 @@ const CommunityLink = ({
   return (
     <div
       onClick={handleClick}
-      className="hover:bg-gray-5 flex h-12 flex-wrap items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer md:w-[300px]"
+      className="hover:bg-gray-5 flex h-12 items-center rounded-xl px-2.5 py-2 transition-colors ease-in hover:cursor-pointer md:w-[300px]"
     >
       <AvatarPreview communityId={community.id} />
-      <div className="ml-2 self-center text-[16px] font-semibold">{community.name}</div>
+      <div className="ml-2 self-center text-[16px] font-semibold whitespace-nowrap overflow-hidden text-ellipsis">{community.name}</div>
     </div>
   );
 };

--- a/packages/pkg.navigation/package.json
+++ b/packages/pkg.navigation/package.json
@@ -18,6 +18,7 @@
     "@xipkg/icons": "0.9.4",
     "@xipkg/modal": "2.1.0",
     "@xipkg/scrollarea": "0.1.0",
+    "@xipkg/tooltip": "^0.1.0",
     "@xipkg/userprofile": "2.2.0",
     "driver.js": "^1.3.1",
     "nanoid": "5.0.7",


### PR DESCRIPTION
Добавила обрезание названия сообщества в меню, если оно превышает по длине контейнер
<img width="335" alt="Снимок экрана 2024-06-25 в 14 44 19" src="https://github.com/xi-effect/xi.app/assets/38958605/6ef22fe3-ea23-4031-a3e8-1e5386c74dda">
<img width="335" alt="Снимок экрана 2024-06-25 в 14 45 03" src="https://github.com/xi-effect/xi.app/assets/38958605/143895aa-71de-4fc1-876b-23f4ea3cdc8a">

 Добавила перенос названия сообщества на новую строку, если название сообщества и заголовок "Добро пожаловать в сообщество" не умещаются на строке
<img width="1368" alt="Снимок экрана 2024-06-25 в 23 34 33" src="https://github.com/xi-effect/xi.app/assets/38958605/8a5142a8-67e9-4c08-a327-b4c54b73c59f">

Добавила скролл
<img width="341" alt="Снимок экрана 2024-06-25 в 23 39 44" src="https://github.com/xi-effect/xi.app/assets/38958605/6f25000a-de80-4af1-9054-d2dbf8127270">
