### PR TITLE
34683590-fix

### DIFF
--- a/packages/pkg.error-page/ErrorPage.tsx
+++ b/packages/pkg.error-page/ErrorPage.tsx
@@ -13,8 +13,8 @@ export type ErrorPagePropsT = {
 };
 
 export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT) => (
-  <main className="3xl:mx-[360px] mx-8 flex h-[100vh] md:mx-[60px] lg:mx-[120px]">
-    <div className="absolute top-[64px] xl:top-[100px]">
+  <main className="3xl:px-[360px] px-8 flex h-[100dvh] w-full md:px-[60px] lg:px-[120px] flex flex-col justify-between overflow-y-scroll gap-8">
+    <div className="min-h-[44px] h-[88px] xl:h-[132px] xl:min-h-[52px] flex items-end">
       <Image
         width={201}
         height={24}
@@ -32,7 +32,7 @@ export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT)
     </div>
     <div className="flex flex-col justify-center">
       <span className="flex flex-col-reverse sm:flex-row sm:gap-1">
-        <h1 className="text-gray-90 mb-4 text-[40px] font-bold sm:text-[48px] xl:text-[64px]">
+        <h1 className="text-gray-90 mb-4 text-[40px] font-bold leading-[48px] sm:text-[48px] sm:leading=[58px] xl:text-[64px] xl:leading-[78px]">
           {title}
         </h1>
         <span className="text-gray-30 text-[28px] font-bold xl:text-[40px]">{errorCode}</span>
@@ -61,5 +61,6 @@ export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT)
       </p>
       <div className="text-gray-80 mt-[64px] text-[16px]">{children}</div>
     </div>
+    <div className="min-h-[44px] h-[88px] xl:h-[132px] xl:min-h-[52px]" />
   </main>
 );

--- a/packages/pkg.error-page/ErrorPage.tsx
+++ b/packages/pkg.error-page/ErrorPage.tsx
@@ -32,15 +32,15 @@ export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT)
     </div>
     <div className="flex flex-col justify-center">
       <span className="flex flex-col-reverse sm:flex-row sm:gap-1">
-        <h1 className="text-gray-90 mb-4 text-[40px] font-bold leading-[48px] sm:text-[48px] sm:leading=[58px] xl:text-[64px] xl:leading-[78px]">
+        <h1 className="text-gray-90 mb-4 text-h3 font-bold sm:text-h2 xl:text-[64px] xl:leading-[78px]">
           {title}
         </h1>
-        <span className="text-gray-30 text-[28px] font-bold xl:text-[40px]">{errorCode}</span>
+        <span className="text-gray-30 text-h6 font-bold xl:text-h3">{errorCode}</span>
       </span>
-      <p className="text-gray-90 mb-16 text-[20px] font-normal sm:text-[24px] xl:text-[30px]">
+      <p className="text-gray-90 mb-16 text-l-base font-normal sm:text-xl-base xl:text-[30px]">
         {text}
       </p>
-      <p className="text-gray-80 text-[16px]">
+      <p className="text-gray-80 text-m-base">
         Если ошибка повторяется — напишите <span className="hidden sm:inline">нам об этом</span>
         <span className="flex flex-col sm:flex-row">
           <span className="flex items-center">
@@ -59,7 +59,7 @@ export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT)
           </span>
         </span>
       </p>
-      <div className="text-gray-80 mt-[64px] text-[16px]">{children}</div>
+      <div className="text-gray-80 mt-[64px] text-m-base">{children}</div>
     </div>
     <div className="min-h-[44px] h-[88px] xl:h-[132px] xl:min-h-[52px]" />
   </main>

--- a/packages/pkg.error-page/ErrorPage.tsx
+++ b/packages/pkg.error-page/ErrorPage.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Link } from '@xipkg/link';
 import { TelegramFilled, MailRounded } from '@xipkg/icons';
-import { Logo } from 'pkg.logo';
+import Image from 'next/image';
 
 export type ErrorPagePropsT = {
   title: string;
@@ -15,12 +15,19 @@ export type ErrorPagePropsT = {
 export const ErrorPage = ({ title, errorCode, text, children }: ErrorPagePropsT) => (
   <main className="3xl:mx-[360px] mx-8 flex h-[100vh] md:mx-[60px] lg:mx-[120px]">
     <div className="absolute top-[64px] xl:top-[100px]">
-      <Logo
-        logoVariant="navigation"
-        logoSize="default"
+      <Image
         width={201}
         height={24}
-        className="xl:h-[32px] xl:w-[269px]"
+        className="xl:h-[32px] xl:w-[269px] block dark:hidden"
+        src="/assets/brand/navigationlogo-default-light.svg"
+        alt="logo"
+      />
+      <Image
+        width={201}
+        height={24}
+        className="xl:h-[32px] xl:w-[269px] hidden dark:block"
+        src="/assets/brand/navigationlogo-default-dark.svg"
+        alt="logo"
       />
     </div>
     <div className="flex flex-col justify-center">

--- a/packages/pkg.error-page/package.json
+++ b/packages/pkg.error-page/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@xipkg/icons": "^0.10.3",
     "@xipkg/link": "^0.3.0",
-    "pkg.logo": "*",
     "next": "^14.2.3",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
<img width="842" alt="Снимок экрана 2024-07-25 в 11 48 05" src="https://github.com/user-attachments/assets/223e3887-51c5-434d-85f8-9a9c17e4893c">
<img width="409" alt="Снимок экрана 2024-07-25 в 11 49 38" src="https://github.com/user-attachments/assets/3eb16f7a-6495-441b-a406-c5ab7762053f">

Исправление проблемы с логотипом на страницах ошибок 